### PR TITLE
Optionally use taskcluster-pulse

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ exchanges.declare({
 
 // Some where in your app, instantiate a publisher
 let publisher = await exchanges.connect({
-  credentials: {username: '...', password: '...'},
-  exchangePrefix: 'v1/', // Prefix for all exchanges (in addition to exchanges/<username>/)
-  validator: await require('taskcluster-lib-validate')(), // instance of taskcluster-lib-validate
+  credentials: {clientId: '...', accessToken: '...'}, // client that can use tc-pulse
+  namespace: '...', // namespace for the pulse exchanges (e.g., `taskcluster-glurble`)
+  expires: '1 day', // lifetime of the namespace
+  exchangePrefix: 'v1/', // Prefix for all exchanges (in addition to exchanges/<namespace>/)
+  validator: await require('taskcluster-lib-validate'), // instance of taskcluster-lib-validate
   monitor: undefined, // optional instance of taskcluster-lib-monitor
 });
 
@@ -101,7 +103,9 @@ create a loader component that calls `setup`, which will also publish the exchan
   publisher: {
     requires: ['cfg', 'validator', 'monitor'],
     setup: ({cfg, validator, monitor}) => exchanges.setup({
-      credentials:        cfg.pulse,
+      credentials:        cfg.app.taskcluster,
+      namespace:          cfg.pulse.namespace,
+      expires:            cfg.pulse.expires,
       exchangePrefix:     cfg.app.exchangePrefix,
       validator:          validator,
       referencePrefix:    'myservice/v1/exchanges.json',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.0.0",
     "promise": "^7.0.0",
     "slugid": "^1.1.0",
-    "taskcluster-client": "^2.4.2"
+    "taskcluster-client": "^2.4.3"
   },
   "devDependencies": {
     "babel-compile": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "debug": "^2.0.0",
     "lodash": "^4.0.0",
     "promise": "^7.0.0",
-    "slugid": "^1.1.0"
+    "slugid": "^1.1.0",
+    "taskcluster-client": "^2.4.2"
   },
   "devDependencies": {
     "babel-compile": "^2.0.0",

--- a/src/exchanges.js
+++ b/src/exchanges.js
@@ -23,9 +23,9 @@ var RECONNECT_INTERVAL = "6 hours";
 
 // Hack to get promises that resolve after 12s without creating a setTimeout
 // for each, instead we create a new promise every 2s and reuse that.
-let _lastTime = 0;
-let _sleeping = null;
-let sleep12Seconds = () => {
+var _lastTime = 0;
+var _sleeping = null;
+var sleep12Seconds = () => {
   let time = Date.now();
   if (time - _lastTime > 2000) {
     _sleeping = new Promise(accept => setTimeout(accept, 12 * 1000));

--- a/src/exchanges.js
+++ b/src/exchanges.js
@@ -12,13 +12,14 @@ var amqplib       = require('amqplib');
 var events        = require('events');
 var util          = require('util');
 var common        = require('./common');
+var taskcluster   = require('taskcluster-client');
 
 // wait 30 seconds before closing a channel, to allow pending operations to flush
 var CLOSE_DELAY = 30 * 1000;
 
 // unconditionally reconnect to pulse on this interval; this ensures the
 // reconnecting logic gets exercised
-var RECONNECT_INTERVAL = 6 * 3600 * 1000;
+var RECONNECT_INTERVAL = "6 hours";
 
 // Hack to get promises that resolve after 12s without creating a setTimeout
 // for each, instead we create a new promise every 2s and reuse that.
@@ -33,10 +34,11 @@ let sleep12Seconds = () => {
 };
 
 /** Class for publishing to a set of declared exchanges */
-var Publisher = function(entries, exchangePrefix, options) {
+var Publisher = function(entries, exchangePrefix, connectionFunc, options) {
   events.EventEmitter.call(this);
   assert(options.validator, "options.validator must be provided");
   this._conn = null;
+  this._connectionFunc = connectionFunc;
   this._channel = null;
   this._connecting = null;
   this._entries = entries;
@@ -165,13 +167,15 @@ Publisher.prototype._connect = async function() {
     return this._connecting;
   }
   return this._connecting = (async () => {
+    let {connectionString, reconnectAt} = await this._connectionFunc();
+
     // Create connection
     let retry = 0;
     while (true) {
       // Try to connect a few times, as DNS randomization is used to ensure we try
       // different nodes
       try {
-        this._conn = await amqplib.connect(this._options.connectionString, {
+        this._conn = await amqplib.connect(connectionString, {
           // Disable TCP Nagle, test don't show any difference in performance, but
           // it probably can't hurt to disable Nagle, this is a low bandwidth
           // application, so it makes a lot of sense to disable Nagle.
@@ -227,7 +231,9 @@ Publisher.prototype._connect = async function() {
     });
 
     // set up to reconnect soon..
-    setTimeout(() => this._reconnect(), RECONNECT_INTERVAL);
+    debug("Will reconnect at " + reconnectAt.toJSON());
+    let reconnectDelay = Math.max(0, reconnectAt - new Date());
+    setTimeout(() => this._reconnect(), reconnectDelay);
 
     return this._channel;
   })().catch(err => {
@@ -237,6 +243,7 @@ Publisher.prototype._connect = async function() {
 };
 
 Publisher.prototype._reconnect = async function() {
+  debug("reconnecting to Pulse");
   this._connecting = null;
 
   // close old connection after a delay, to allow any pending operations to
@@ -447,16 +454,31 @@ Exchanges.prototype.configure = function(options) {
  *
  * Options:
  * {
- *   credentials: {
- *     username:        '...',   // Pulse username
- *     password:        '...',   // Pulse password
- *     hostname:        '...'    // Hostname, defaults to pulse.mozilla.org
- *   },
- *   connectionString:  '...',   // AMQP connection string, if not credentials
- *   exchangePrefix:    '...',   // Exchange prefix
+ *   credentials: .. (see below)
+ *   namespace: '...',           // pulse namespace (usually taskcluster-foo)
+ *   expires: '1 year',           // time after which the namespace expires
+ *   contact: 'foo@bar',         // contact email for the pulse namespace
+ *   exchangePrefix:    '...',   // Exchange prefix ('v1/')
  *   validator:                  // Instance of base.validator
  *   monitor:           await require('taskcluster-lib-monitor')({...}),
  * }
+ *
+ * Given a set of permanent Pulse credentials, pass credentials:
+ * {
+ *   username:        '...',   // Pulse username
+ *   password:        '...',   // Pulse password
+ *   hostname:        '...'    // Hostname, defaults to pulse.mozilla.org
+ * },
+ * In this case, the namespace will default to the username.
+ *
+ * To use Taskcluster-Pulse, pass credentials:
+ * {
+ *   clientId: '...', // client with scope `pulse:claim-namespace:<namespace>`
+ *   accessToken: '...',
+ *   certificate: '...', // if using temporary credentials
+ * }
+ *
+ * For a fake publisher, pass credentials: {fake: true}.
  *
  * This method will connect to AMQP server and return a instance of Publisher.
  * The publisher will have a method for each declared exchange, the method
@@ -478,50 +500,65 @@ Exchanges.prototype.connect = async function(options) {
     credentials:        {}
   });
 
-  // Check we have a connection string
-  assert(options.connectionString ||
-         (options.credentials.username && options.credentials.password) ||
-         options.credentials.fake,
-         "ConnectionString or credentials must be provided");
   assert(options.validator, "A base.validator function must be provided.");
+  assert(options.credentials, "Some kind of credentials are required.");
+  let credentials = options.credentials;
+  assert(options.namespace || credentials.username, "Must provide a namespace.");
 
   // Find exchange prefix, may be further prefixed if pulse credentials
   // are given
-  var exchangePrefix = options.exchangePrefix;
-
-  // If we have pulse credentials, construct connectionString
-  if (options.credentials &&
-      options.credentials.username &&
-      options.credentials.password) {
-    options.connectionString = [
-      'amqps://',         // Ensure that we're using SSL
-      options.credentials.username,
-      ':',
-      options.credentials.password,
-      '@',
-      options.credentials.hostname || 'pulse.mozilla.org',
-      ':',
-      5671                // Port for SSL
-    ].join('');
-    // Also construct exchange prefix
-    exchangePrefix = [
-      'exchange',
-      options.credentials.username,
-      options.exchangePrefix
-    ].join('/');
-  }
+  var exchangePrefix = [
+    'exchange',
+    options.namespace || credentials.username,
+    options.exchangePrefix,
+  ].join('/');
 
   // Clone entries for consistency
   var entries = _.cloneDeep(this._entries);
 
-  if (options.credentials.fake) {
+  // make a function to get a connectionString, based on options.
+  let connectionFunc;
+  if (credentials.username &&
+      credentials.password) {
+    let connectionString = [
+      'amqps://',         // Ensure that we're using SSL
+      credentials.username,
+      ':',
+      credentials.password,
+      '@',
+      credentials.hostname || 'pulse.mozilla.org',
+      ':',
+      5671                // Port for SSL
+    ].join('');
+    connectionFunc = async () => ({
+      connectionString,
+      reconnectAt: taskcluster.fromNow(RECONNECT_INTERVAL),
+    });
+  } else if (credentials.clientId && credentials.accessToken) {
+    assert(options.namespace, "Must specify a namespace");
+    assert(options.expires, "Must specify a namespace expiration");
+
+    let tcPulse = new taskcluster.Pulse({credentials});
+    connectionFunc = async () => {
+      let claim = await tcPulse.claimNamespace(options.namespace, {
+        expires: taskcluster.fromNow(options.expires),
+        contact: options.contact,
+      });
+      return {
+        connectionString: claim.connectionString,
+        reconnectAt: new Date(claim.reclaimAt),
+      };
+    };
+  } else if (credentials.fake) {
     // only load fake on demand
     var FakePublisher = require('./fake');
     return new FakePublisher(entries, exchangePrefix, options);
+  } else {
+    throw new Error("invalid credentials");
   }
 
   // return publisher
-  let publisher = new Publisher(entries, exchangePrefix, options);
+  let publisher = new Publisher(entries, exchangePrefix, connectionFunc, options);
   await publisher._connect();
   return publisher;
 };

--- a/test/fakepublisher_test.js
+++ b/test/fakepublisher_test.js
@@ -71,7 +71,7 @@ suite("Exchanges (FakePublisher)", function() {
 
   // Test that we can connect to AMQP server
   test("connect", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({namespace: 'fake'}).then(function(publisher) {
       assert(publisher instanceof FakePublisher,
              "Should get an instance of exchanges.Publisher");
     });
@@ -80,7 +80,7 @@ suite("Exchanges (FakePublisher)", function() {
   // Test that we can publish messages
   test("publish message", function() {
     var published = []
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({namespace: 'fake'}).then(function(publisher) {
       publisher.on('fakePublish', function(info) { published.push(info); });
       return publisher.testExchange({someString: "My message"}, {
         testId:           "myid",
@@ -89,7 +89,7 @@ suite("Exchanges (FakePublisher)", function() {
       });
     }).then(function() {
       assert(_.isEqual(published, [{
-        exchange: 'test-exchange',
+        exchange: 'exchange/fake/test-exchange',
         routingKey: 'myid.some.string.with.dots._._.-constant-',
         payload: { someString: 'My message' },
         CCs: [] }]));

--- a/test/pulsepublisher_test.js
+++ b/test/pulsepublisher_test.js
@@ -1,4 +1,4 @@
-suite("Exchanges (Publish on Pulse)", function() {
+suite("Publish to Pulse", function() {
   var assert     = require('assert');
   var subject    = require('../');
   var config     = require('typed-env-config');
@@ -16,7 +16,7 @@ suite("Exchanges (Publish on Pulse)", function() {
   var cfg = config({});
 
   if (!cfg.pulse.password) {
-    console.log("Skipping 'pulse publisher', missing config file: user-config.yml");
+    console.log("Skipping tests due to missing cfg.pulse");
     this.pending = true;
   }
 
@@ -94,15 +94,12 @@ suite("Exchanges (Publish on Pulse)", function() {
     });
 
     // Set options on exchanges
-    exchanges.configure({
-      validator:              validate,
-      credentials:            cfg.pulse
-    });
+    exchanges.configure({validator: validate});
   });
 
   // Test that we can connect to AMQP server
   test("connect", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       assert(publisher instanceof subject.Publisher,
              "Should get an instance of exchanges.Publisher");
     });
@@ -110,7 +107,7 @@ suite("Exchanges (Publish on Pulse)", function() {
 
   // Test that we can publish messages
   test("publish message", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       return publisher.testExchange({someString: "My message"}, {
         testId:           "myid",
         taskRoutingKey:   "some.string.with.dots",
@@ -119,12 +116,11 @@ suite("Exchanges (Publish on Pulse)", function() {
     });
   });
 
-
   /*
   // Test that we can publish messages fast
   test("publish message 400", function() {
     var promises = [];
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       for (var i = 0; i < 400; i++) {
         promises.push(new Promise(function(accept) {
           setTimeout(accept, Math.floor(i / 4));
@@ -150,7 +146,7 @@ suite("Exchanges (Publish on Pulse)", function() {
   // Test that we can publish messages fast
   test("publish message 400", function() {
     var promises = [];
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       for (var i = 0; i < 400; i++) {
         promises.push(publisher.testExchange({someString: "My message" + i}, {
           testId:           "myid",
@@ -165,7 +161,7 @@ suite("Exchanges (Publish on Pulse)", function() {
   /*
   // Test that we can publish messages fast (for TCP Nagle disable test)
   test("publish message", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       var i = 0;
       var loop = function() {
         i += 1;
@@ -187,7 +183,7 @@ suite("Exchanges (Publish on Pulse)", function() {
 
   // Test that we can publish messages
   test("publish message w. number in routing key", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       return publisher.testExchange({someString: "My message"}, {
         testId:           "myid",
         taskRoutingKey:   "some.string.with.dots",
@@ -199,7 +195,7 @@ suite("Exchanges (Publish on Pulse)", function() {
 
   // Test publication fails on schema violation
   test("publish error w. schema violation", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       return publisher.testExchange({
         someString:   "My message",
         "volation":   true
@@ -219,7 +215,7 @@ suite("Exchanges (Publish on Pulse)", function() {
 
   // Test publication fails on required key missing
   test("publish error w. required key missing", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       return publisher.testExchange({
         someString:   "My message",
       }, {
@@ -236,7 +232,7 @@ suite("Exchanges (Publish on Pulse)", function() {
 
   // Test publication fails on size violation
   test("publish error w. size violation", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       return publisher.testExchange({
         someString:   "My message",
       }, {
@@ -254,7 +250,7 @@ suite("Exchanges (Publish on Pulse)", function() {
 
   // Test publication fails on multiple words
   test("publish error w. multiple words", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       return publisher.testExchange({
         someString:   "My message",
       }, {
@@ -297,7 +293,7 @@ suite("Exchanges (Publish on Pulse)", function() {
         messages.push(msg);
       });
     }).then(function() {
-      return exchanges.connect().then(function(publisher) {
+      return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
         return publisher.testExchange({someString: "My message"}, {
           testId:           "myid",
           taskRoutingKey:   "some.string.with.dots",
@@ -341,7 +337,7 @@ suite("Exchanges (Publish on Pulse)", function() {
         messages.push(msg);
       });
     }).then(function() {
-      return exchanges.connect().then(function(publisher) {
+      return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
         return publisher.testExchange({someString: "My message"}, {
           testId:           "myid",
           taskRoutingKey:   "some.string.with.dots",
@@ -357,7 +353,7 @@ suite("Exchanges (Publish on Pulse)", function() {
 
   // Test that we can publish messages with large CC
   test("publish message (huge CC)", function() {
-    return exchanges.connect().then(function(publisher) {
+    return exchanges.connect({credentials: cfg.pulse}).then(function(publisher) {
       return publisher.testExchange({someString: "My message"}, {
         testId:           "myid",
         taskRoutingKey:   "some.string.with.dots",
@@ -385,6 +381,7 @@ suite("Exchanges (Publish on Pulse)", function() {
     assert(_.keys(monitor.counts).length === 0, "We shouldn't have any points");
     return exchanges.connect({
       monitor,
+      credentials: cfg.pulse,
     }).then(function(publisher) {
       return publisher.testExchange({someString: "My message"}, {
         testId:           "myid",
@@ -393,6 +390,48 @@ suite("Exchanges (Publish on Pulse)", function() {
       });
     }).then(function() {
       assert(_.keys(monitor.counts).length === 1, "We should have one point");
+    });
+  });
+
+  suite('with taskcluster credentials', function() {
+    if (!cfg.taskcluster) {
+      console.log("Skipping tests due to missing cfg.taskcluster");
+      this.pending = true;
+    }
+
+    test("publish message (and receive)", async function() {
+      var queue = 'queue/' + cfg.pulse.username + '/test/' + slugid.v4(),
+          namespace = 'taskcluster-tests-' + slugid.nice();
+      var messages = [];
+
+      let publisher = await exchanges.connect({
+        credentials: cfg.taskcluster,
+        namespace,
+        expires: '1 hour',
+      });
+
+      let conn = await amqplib.connect(connectionString);
+      let channel = await conn.createConfirmChannel();
+      await channel.assertQueue(queue, {
+        exclusive:  true,
+        durable:    false,
+        autoDelete: true,
+      });
+      var testExchange = 'exchange/' + namespace + '/test-exchange';
+      await channel.bindQueue(queue, testExchange, 'myid.#');
+      await channel.consume(queue, function(msg) {
+        msg.content = JSON.parse(msg.content.toString());
+        //console.log(JSON.stringify(msg, null, 2));
+        messages.push(msg);
+      });
+
+      await publisher.testExchange({someString: "My message"}, {
+        testId:           "myid",
+        taskRoutingKey:   "some.string.with.dots",
+        state:            undefined // Optional
+      });
+      await new Promise(function(accept) {setTimeout(accept, 400);});
+      assert(messages.length == 1, "Didn't get exactly one message");
     });
   });
 });

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -3,6 +3,10 @@ defaults:
   aws:
     accessKeyId:      "..."
     secretAccessKey:  "..."
+  # this client should have pulse:namespace:taskcluster-tests-*
+  taskcluster:
+    clientId: "..."
+    accessToken: "..."
   pulse:
     username: "..."
     password: "..."

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,6 +1447,23 @@ taskcluster-client@^1.0.1:
   optionalDependencies:
     sockjs-client "^1.0.3"
 
+taskcluster-client@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-2.4.2.tgz#f167d1bb71e2c2e002adbea98139475a2f10ab87"
+  dependencies:
+    amqplib "^0.5.1"
+    debug "^2.1.3"
+    hawk "^2.3.1"
+    lodash "^3.6.0"
+    promise "^6.1.0"
+    slugid "^1.1.0"
+    superagent "~1.7.0"
+    superagent-hawk "^0.0.6"
+    superagent-promise "^0.2.0"
+    url-join "^0.0.1"
+  optionalDependencies:
+    sockjs-client "^1.0.3"
+
 taskcluster-lib-monitor@^4.1.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/taskcluster-lib-monitor/-/taskcluster-lib-monitor-4.5.0.tgz#f0b1aab65b6eebb97563d5bcd617816b0018c100"


### PR DESCRIPTION
This unconditionally adds a 30-minute reconnect to publishers using the normal pulse credentials, then goes on to add automatic reconnecting via tc-pulse (which requires it). The tests actually talk to tc-pulse, although they do not re-claim.

I think the rollout would look something like this:
 * relase this as a major version change (tests are incompatible)
 * deploy on services one at a time, without changing config
 * do the same with tc-client
 * update config on one service at a time to use tc-pulse for both publishing and/or listening
 * delete old pulse users