### PR TITLE
Allow using {fake: true} with new namespaces changes

### DIFF
--- a/src/exchanges.js
+++ b/src/exchanges.js
@@ -515,13 +515,13 @@ Exchanges.prototype.connect = async function(options) {
   assert(options.validator, 'A base.validator function must be provided.');
   assert(options.credentials, 'Some kind of credentials are required.');
   let credentials = options.credentials;
-  assert(options.namespace || credentials.username, 'Must provide a namespace.');
+  assert(options.namespace || credentials.username || credentials.fake === 'true', 'Must provide a namespace.');
 
   // Find exchange prefix, may be further prefixed if pulse credentials
   // are given
   var exchangePrefix = [
     'exchange',
-    options.namespace || credentials.username,
+    options.namespace || credentials.username || 'fake',
     options.exchangePrefix,
   ].join('/');
 


### PR DESCRIPTION
Without this, pulse-publisher-based tests fail when upgrading pulse-publisher in our services. With this change, the tests still fail, but because of

```
      -    "exchange": "exchange/fake/v1/release"                                         
      +    "exchange": "v1/release"          

```

This seems like a difference that is intended and I can just update the values we're asserting in the tests.