### PR TITLE
Bug 1465166 - [BREAKING] require projectName when declaring, publish …

### DIFF
--- a/src/schemas/exchanges-reference.json
+++ b/src/schemas/exchanges-reference.json
@@ -100,8 +100,7 @@
                     },
                     "schema": {
                         "type": "string",
-                        "format": "uri",
-                        "description": "JSON schema for messages posted on this exchange"
+                        "description": "JSON schema for messages on this exchange. The value must be a relative URI, based on the service's schema location; that is, based at `<rootUrl>/schemas/<serviceName`."
                     }
                 },
                 "additionalProperties": false,

--- a/test/exchanges_publish_test.js
+++ b/test/exchanges_publish_test.js
@@ -15,6 +15,7 @@ suite('Exchanges', function() {
     // Create an exchanges
     var exchanges = new subject({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',

--- a/test/exchanges_test.js
+++ b/test/exchanges_test.js
@@ -8,6 +8,7 @@ suite('Exchanges', function() {
     // Create an exchanges
     var exchanges = new Exchanges({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',
@@ -56,6 +57,7 @@ suite('Exchanges', function() {
     // Create an exchanges
     var exchanges = new Exchanges({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',
@@ -141,6 +143,7 @@ suite('Exchanges', function() {
     // Create an exchanges
     var exchanges = new Exchanges({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',
@@ -188,71 +191,10 @@ suite('Exchanges', function() {
       CCBuilder:          function() { return []; },
     });
 
-    var reference = exchanges.reference({rootUrl: libUrls.testRootUrl()});
+    var reference = exchanges.reference();
     assert.equal(reference.version, 0);
     assert.equal(reference.serviceName, 'test');
-    assert.equal(reference.exchangePrefix, 'exchange/taskcluster-fake/v1/');
-  });
-
-  test('reference (pulse)', function() {
-    // Create an exchanges
-    var exchanges = new Exchanges({
-      serviceName:        'test',
-      version:            'v1',
-      title:              'Title for my Events',
-      description:        'Test exchanges used for testing things only',
-    });
-    // Check that we can declare an exchange
-    exchanges.declare({
-      exchange:           'test-exchange',
-      name:               'testExchange',
-      title:              'Test Exchange',
-      description:        'Place we post message for **testing**.',
-      routingKey: [
-        {
-          name:           'testId',
-          summary:        'Identifier that we use for testing',
-          multipleWords:  false,
-          required:       true,
-          maxSize:        22,
-        }, {
-          name:           'taskRoutingKey',
-          summary:        'Test specific routing-key: `test.key`',
-          multipleWords:  true,
-          required:       true,
-          maxSize:        128,
-        }, {
-          name:           'state',
-          summary:        'State of something',
-          multipleWords:  false,
-          required:       false,
-          maxSize:        16,
-        }, {
-          name:           'myConstant',
-          summary:        'Some constant to test',
-          constant:       '-constant-',
-        },
-      ],
-      schema: 'exchanges-test.yml',
-      messageBuilder:     function(test) { return test; },
-      routingKeyBuilder:  function(test, state) {
-        return {
-          testId:           test.id,
-          taskRoutingKey:   test.key,
-          state:            state,
-        };
-      },
-      CCBuilder:          function() { return []; },
-    });
-
-    var reference = exchanges.reference({
-      rootUrl: libUrls.testRootUrl(),
-      credentials: {
-        username:   'test-user',
-      },
-    });
-
-    assert(reference.exchangePrefix === 'exchange/test-user/v1/');
+    assert.equal(reference.exchangePrefix, 'exchange/taskcluster-test/v1/');
   });
 
   // Test that we can't declare too long routing keys
@@ -260,6 +202,7 @@ suite('Exchanges', function() {
     // Create an exchanges
     var exchanges = new Exchanges({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',
@@ -317,6 +260,7 @@ suite('Exchanges', function() {
     // Create an exchanges
     var exchanges = new Exchanges({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',
@@ -373,6 +317,7 @@ suite('Exchanges', function() {
     // Create an exchanges
     var exchanges = new Exchanges({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',

--- a/test/fakepublisher_test.js
+++ b/test/fakepublisher_test.js
@@ -13,6 +13,7 @@ suite('Exchanges (FakePublisher)', function() {
   setup(async function() {
     exchanges = new subject({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',
@@ -63,6 +64,7 @@ suite('Exchanges (FakePublisher)', function() {
     var validate = await validator({
       rootUrl: libUrls.testRootUrl(),
       serviceName: 'test',
+      projectName: 'taskcluster-test',
       folder:  path.join(__dirname, 'schemas'),
     });
 

--- a/test/pulsepublisher_test.js
+++ b/test/pulsepublisher_test.js
@@ -40,6 +40,7 @@ suite('Publish to Pulse', function() {
   setup(async function() {
     exchanges = new subject({
       serviceName:        'test',
+      projectName:        'taskcluster-test',
       version:            'v1',
       title:              'Title for my Events',
       description:        'Test exchanges used for testing things only',
@@ -90,6 +91,7 @@ suite('Publish to Pulse', function() {
     var validate = await validator({
       rootUrl: libUrls.testRootUrl(),
       serviceName: 'test',
+      projectName: 'taskcluster-test',
       folder:  path.join(__dirname, 'schemas'),
     });
 


### PR DESCRIPTION
…refs with relative 'schema'

The exchange is now always fixed at `exchanges/<projectName>/<version>/<name>`.
That means that projectName is required when declaring Exchanges.

In the reference schema, `schema` is now a relative URI, relative to the
service's schemas.  This matches the behavior of taskcluster-lib-api.