### PR TITLE
Include the correct relative uri in entries' `schema`

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -3,7 +3,7 @@ var debug         = require('debug')('base:exchanges');
 var libUrls       = require('taskcluster-lib-urls');
 
 exports.validateMessage = function(rootUrl, serviceName, version, validator, entry, message) {
-  const schema = libUrls.schema(rootUrl, serviceName, `${version}/${entry.schema}`);
+  const schema = libUrls.schema(rootUrl, serviceName, entry.schema);
   var err = validator(message, schema);
   if (err) {
     debug('Failed validate message: %j against schema: %s, error: %j',

--- a/src/exchanges.js
+++ b/src/exchanges.js
@@ -374,6 +374,7 @@ Exchanges.prototype.declare = function(options) {
   });
 
   assert(!options.schema.startsWith('http'), 'schema must be a bare filename in schemas/v1');
+  options.schema = `${this._options.version}/${options.schema.replace(/ya?ml$/, 'json#')}`;
 
   // Validate routingKey declaration
   assert(options.routingKey instanceof Array,
@@ -628,7 +629,7 @@ Exchanges.prototype.reference = function() {
           return _.pick(key, 'name', 'summary', 'constant',
             'multipleWords', 'required');
         }),
-        schema: `${this._options.version}/${entry.schema}`,
+        schema: entry.schema,
       };
     }),
   };

--- a/test/exchanges_test.js
+++ b/test/exchanges_test.js
@@ -195,6 +195,9 @@ suite('Exchanges', function() {
     assert.equal(reference.version, 0);
     assert.equal(reference.serviceName, 'test');
     assert.equal(reference.exchangePrefix, 'exchange/taskcluster-test/v1/');
+    // schema property is a relative uri that, when combined with the base
+    // uri for the service, will generate the schema's $id
+    assert.equal(reference.entries[0].schema, 'v1/exchanges-test.json#');
   });
 
   // Test that we can't declare too long routing keys


### PR DESCRIPTION
This produces the expected uri relative to the root of the service's
schemas (e.g., https://tc.example.com/schemas/myservice), and matches
the schema's `$id` (ending in `.json#`).